### PR TITLE
Fix 'null this' crash in client app.

### DIFF
--- a/plugins/voxelman/world/clientworld.d
+++ b/plugins/voxelman/world/clientworld.d
@@ -155,6 +155,7 @@ public:
 		chunkEditor = new ChunkEditor(NUM_CHUNK_LAYERS, chunkManager);
 		worldAccess = new WorldAccess(chunkManager, chunkEditor);
 		entityAccess = new BlockEntityAccess(chunkManager, chunkEditor);
+		chunkObserverManager = new ChunkObserverManager();
 
 		chunkManager.setLayerInfo(METADATA_LAYER, ChunkLayerInfo(BLOCK_METADATA_UNIFORM_FILL_BITS));
 		chunkManager.onChunkRemovedHandler = &chunkMeshMan.onChunkRemoved;
@@ -164,7 +165,6 @@ public:
 
 		chunkMeshMan.getDimensionBorders = &dimMan.dimensionBorders;
 
-		chunkObserverManager = new ChunkObserverManager();
 		chunkObserverManager.loadChunkHandler = &chunkManager.loadChunk;
 		chunkObserverManager.unloadChunkHandler = &chunkManager.unloadChunk;
 		chunkObserverManager.chunkObserverAddedHandler = &handleChunkObserverAdded;


### PR DESCRIPTION
This crash was caused by the fact that the following line:

`chunkEditor.addServerObserverHandler = &chunkObserverManager.addServerObserver;`

occured before the chunkObserverManager object was initialised.

Interestingly the crash occured not in the initialization stage, but after attempting to edit the world. So it seems that it is possible in D to make a delegate from a member function of a `null` object. I wonder if `@safe` would catch this error?