### PR TITLE
More consistent use of size_t in place of (u)int/(u)long in gui/textedit files

### DIFF
--- a/source/voxelman/gui/textedit/cursor.d
+++ b/source/voxelman/gui/textedit/cursor.d
@@ -9,7 +9,7 @@ import voxelman.gui.textedit.linebuffer;
 
 struct Cursor
 {
-	ulong byteOffset;
+	size_t byteOffset;
 	int line;
 }
 

--- a/source/voxelman/gui/textedit/linebuffer.d
+++ b/source/voxelman/gui/textedit/linebuffer.d
@@ -16,7 +16,7 @@ enum int NUM_BYTES_MASK = NUM_BYTES_HIGH_BIT - 1;
 
 struct LineInfo
 {
-	this(int startOffset, int numBytes, int numBytesEol)
+	this(size_t startOffset, size_t numBytes, size_t numBytesEol)
 	{
 		assert(numBytesEol > 0 && numBytesEol < 3);
 		this.startOffset = startOffset;
@@ -27,11 +27,11 @@ struct LineInfo
 	size_t numBytesStorage;  // excluding newline
 
 	size_t endOffset() { return startOffset + numBytes; }
-	int nextStartOffset() { return startOffset + numBytesTotal; }
-	int numBytesEol() { return (numBytesStorage >> 31) + 1; }
-	int numBytes() { return numBytesStorage & NUM_BYTES_MASK; } // excluding newline
+	size_t nextStartOffset() { return startOffset + numBytesTotal; }
+	size_t numBytesEol() { return (numBytesStorage >> 31) + 1; }
+	size_t numBytes() { return numBytesStorage & NUM_BYTES_MASK; } // excluding newline
 	void numBytes(int bytes) { numBytesStorage = numBytesStorage & NUM_BYTES_HIGH_BIT | bytes; } // excluding newline
-	int numBytesTotal() { return numBytes + numBytesEol; }
+	size_t numBytesTotal() { return numBytes + numBytesEol; }
 
 	void toString(scope void delegate(const(char)[]) sink)
 	{
@@ -70,7 +70,7 @@ struct LineInfoBuffer
 	}
 	alias opIndex = lineInfo;
 
-	int lineStartOffset(int lineIndex)
+	size_t lineStartOffset(int lineIndex)
 	{
 		if (numLines == 0) return 0;
 		updateOffsetsToLine(lineIndex);
@@ -78,21 +78,21 @@ struct LineInfoBuffer
 	}
 
 	// Does not include newline bytes
-	int numLineBytes(int lineIndex)
+	size_t numLineBytes(int lineIndex)
 	{
 		if (numLines == 0) return 0;
 		updateOffsetsToLine(lineIndex);
 		return lines[lineIndex].numBytes;
 	}
 
-	int numLineTotalBytes(int lineIndex)
+	size_t numLineTotalBytes(int lineIndex)
 	{
 		if (numLines == 0) return 0;
 		updateOffsetsToLine(lineIndex);
 		return lines[lineIndex].numBytesTotal;
 	}
 
-	int lineEndOffset(int lineIndex)
+	size_t lineEndOffset(int lineIndex)
 	{
 		if (numLines == 0) return 0;
 		updateOffsetsToLine(lineIndex);
@@ -166,7 +166,7 @@ struct LineInfoBuffer
 				{
 					// first line
 					auto totalNewBytes = oldBytesLeft + lineBytes;
-					lines[at.line] = LineInfo(firstLine.startOffset, cast(int)totalNewBytes, cast(int)eolBytes);
+					lines[at.line] = LineInfo(firstLine.startOffset, totalNewBytes, eolBytes);
 				}
 				else
 					lines.putAt(lineIndex, LineInfo(cast(int)(at.byteOffset + startOffset), cast(int)lineBytes, cast(int)eolBytes));
@@ -188,7 +188,7 @@ struct LineInfoBuffer
 		{
 			// and first line. no trailing newline
 			auto totalNewBytes = oldBytesLeft + lineBytes + oldBytesRight;
-			lines[at.line] = LineInfo(firstLine.startOffset, cast(int)totalNewBytes, cast(int)oldEolBytes);
+			lines[at.line] = LineInfo(firstLine.startOffset, totalNewBytes, oldEolBytes);
 		}
 		else
 		{
@@ -230,7 +230,7 @@ struct LineInfoBuffer
 		//-writefln("totalFirstBytes %s", totalFirstBytes);
 
 		// update data in first line
-		lines[from.line] = LineInfo(first.startOffset, cast(int)totalFirstBytes, last.numBytesEol);
+		lines[from.line] = LineInfo(first.startOffset, totalFirstBytes, last.numBytesEol);
 		//-writefln("lines[from.line] = %s", lines[from.line]);
 
 		// remove extra lines

--- a/source/voxelman/gui/textedit/linebuffer.d
+++ b/source/voxelman/gui/textedit/linebuffer.d
@@ -23,10 +23,10 @@ struct LineInfo
 		this.numBytesStorage = ((numBytesEol-1) << 31) | numBytes;
 	}
 
-	int startOffset;
-	int numBytesStorage;  // excluding newline
+	size_t startOffset;
+	size_t numBytesStorage;  // excluding newline
 
-	int endOffset() { return startOffset + numBytes; }
+	size_t endOffset() { return startOffset + numBytes; }
 	int nextStartOffset() { return startOffset + numBytesTotal; }
 	int numBytesEol() { return (numBytesStorage >> 31) + 1; }
 	int numBytes() { return numBytesStorage & NUM_BYTES_MASK; } // excluding newline

--- a/source/voxelman/gui/textedit/lineedit.d
+++ b/source/voxelman/gui/textedit/lineedit.d
@@ -54,16 +54,16 @@ struct LineEditLogic
 		copyText(sel.start.byteOffset, sel.end.byteOffset);
 	}
 
-	void copyText(ulong from, ulong to)
+	void copyText(size_t from, size_t to)
 	{
 		auto copiedText = textData[from..to].toChunkedRange.byItem;
 		ctx.clipboard = copiedText;
 	}
 
-	ulong length() { return textData.length; }
+	size_t length() { return textData.length; }
 	alias opDollar = length;
 
-	ChunkedRange!char opSlice(ulong from, ulong to)
+	ChunkedRange!char opSlice(size_t from, size_t to)
 	{
 		return textData[from..to].toChunkedRange;
 	}
@@ -174,20 +174,20 @@ struct LineEditLogic
 	}
 	import std.utf : stride, strideBack;
 
-	uint strideAt(ulong offset)
+	uint strideAt(size_t offset)
 	{
 		auto str = textData[offset..$];
 		return stride(str);
 	}
 
-	ulong nextOffset(ulong offset)
+	size_t nextOffset(size_t offset)
 	{
 		return offset + strideAt(offset);
 	}
 
-	ulong prevOffset(ulong offset)
+	size_t prevOffset(size_t offset)
 	{
-		return offset - strideBack(textData[0..offset]);
+		return offset - strideBack(textData[0u..offset]);
 	}
 
 	Cursor moveCursor(Cursor cur, MoveCommand com)

--- a/source/voxelman/gui/textedit/messagelog.d
+++ b/source/voxelman/gui/textedit/messagelog.d
@@ -21,7 +21,7 @@ class MessageLogTextModel : TextModel
 
 	int numLines() { return text.lines.numLines; }
 	int lastLine() { return text.lines.lastLine; }
-	ChunkedRange!char opSlice(ulong from, ulong to) { return (*text)[from..to]; }
+	ChunkedRange!char opSlice(size_t from, size_t to) { return (*text)[from..to]; }
 	LineInfo lineInfo(int line) { return text.lineInfo(line); }
 
 	void onCommand(EditorCommand com) { text.onCommand(com); }
@@ -53,7 +53,7 @@ struct MessageLog
 	alias opDollar = length;
 	LineInfo lineInfo(int line) { return lines.lineInfo(line); }
 
-	ChunkedRange!char opSlice(ulong from, ulong to)
+	ChunkedRange!char opSlice(size_t from, size_t to)
 	{
 		return textData[from..to].toChunkedRange;
 	}

--- a/source/voxelman/gui/textedit/texteditor.d
+++ b/source/voxelman/gui/textedit/texteditor.d
@@ -72,7 +72,7 @@ class EditorTextModel : TextModel
 
 	int numLines() { return editor.lines.numLines; }
 	int lastLine() { return editor.lines.lastLine; }
-	ChunkedRange!char opSlice(ulong from, ulong to) { return editor.textData[from..to].toChunkedRange; }
+	ChunkedRange!char opSlice(size_t from, size_t to) { return editor.textData[from..to].toChunkedRange; }
 	LineInfo lineInfo(int line) { return editor.lines.lineInfo(line); }
 
 	void onCommand(EditorCommand com) { editor.onCommand(com); }
@@ -206,7 +206,7 @@ mixin template ReadHelpers()
 		copyText(sel.start.byteOffset, sel.end.byteOffset);
 	}
 
-	void copyText(ulong from, ulong to)
+	void copyText(size_t from, size_t to)
 	{
 		//MonoTime copyStart = MonoTime.currTime;
 		auto copiedText = textData[from..to].toChunkedRange.byItem;
@@ -231,20 +231,20 @@ mixin template ReadHelpers()
 			return selection.normalized;
 	}
 
-	uint strideAt(ulong offset)
+	uint strideAt(size_t offset)
 	{
 		auto str = textData[offset..$];
 		return stride(str);
 	}
 
-	ulong nextOffset(ulong offset)
+	size_t nextOffset(size_t offset)
 	{
 		return offset + strideAt(offset);
 	}
 
-	ulong prevOffset(ulong offset)
+	size_t prevOffset(size_t offset)
 	{
-		return offset - strideBack(textData[0..offset]);
+		return offset - strideBack(textData[0u..offset]);
 	}
 
 	Cursor moveCursor(Cursor cur, MoveCommand com)

--- a/source/voxelman/gui/textedit/texteditorview.d
+++ b/source/voxelman/gui/textedit/texteditorview.d
@@ -165,8 +165,8 @@ struct TextEditorViewportLogic
 
 			foreach(line; firstVisibleSelectedLine..lastVisibleSelectedLine+1)
 			{
-				ulong lineStart = 0;
-				ulong lineEnd;
+				size_t lineStart = 0;
+				size_t lineEnd;
 
 				auto lineInfo = editor.lineInfo(line);
 

--- a/source/voxelman/gui/textedit/textmodel.d
+++ b/source/voxelman/gui/textedit/textmodel.d
@@ -17,7 +17,7 @@ interface TextModel
 
 	int numLines();
 	int lastLine();
-	ChunkedRange!char opSlice(ulong from, ulong to);
+	ChunkedRange!char opSlice(size_t from, size_t to);
 	LineInfo lineInfo(int line);
 
 	void onCommand(EditorCommand com);


### PR DESCRIPTION
The first commit fixes 32-bit compilation but breaks 64-bit compilation, the second commit fixes 64-bit compilation as well. I don't see any more errors or warnings about int/long incompatibility under either 32-bit or 64-bit compilation.